### PR TITLE
Added "autopass" as extra host to fix license issue

### DIFF
--- a/sca.dockerapp
+++ b/sca.dockerapp
@@ -28,6 +28,7 @@ services:
     extra_hosts:
         - "nimbusserver.aos.com:172.50.0.1"
         - "nimbusserver:172.50.0.1"
+        - "autopass:172.50.10.10"
 networks:
    demo-net:
      external: true


### PR DESCRIPTION
sca image can't get an updated license since it doesn't know "autopass".
Adding **autopass** to _extra_hosts_ resolves this minor issue